### PR TITLE
gains `PULL_REQUEST_TEMPLATE.md`

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@
 Closes: 
 
 ## Testing
-<how you validated behavior — automated tests or manual reproduction>
+<!-- how you validated behavior — automated tests or manual reproduction -->
 
 ## Checklist
 - [ ] PR is focused on a single concern

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ## Summary
-<what changed and why>
+<!-- what changed and why -->
 
 ## Related issues
 Closes: 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## Summary
+<what changed and why>
+
+## Related issues
+Closes: 
+
+## Testing
+<how you validated behavior — automated tests or manual reproduction>
+
+## Checklist
+- [ ] PR is focused on a single concern
+- [ ] Tests pass locally and in CI
+- [ ] Docs updated for user-visible changes
+- [ ] AI-assisted portions declared (see [CONTRIBUTING.md](https://github.com/RMI/.github/blob/main/CONTRIBUTING.md))

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository holds RMI's organization-wide GitHub community health defaults. Files here apply to every repository in the org that doesn't provide it's own.
 
+## What Lives Here
+
+- `PULL_REQUEST_TEMPLATE.md`: a default PR template, aligned with the process guidance in [`practices/process/pull_request.md`](https://github.com/RMI/practices/blob/main/process/pull_request.md).
+
 ## How This Repo Relates to `practices`
 
 - `practices`[https://github.com/RMI/practices] is the source of truth for guidance: the "why" and "how" behind our engineering standards.


### PR DESCRIPTION
Gains a general pull request template, based loosely on [practices/process/pull_request.md](https://github.com/RMI/practices/blob/main/process/pull_request.md).
